### PR TITLE
Add env example and update README

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+GEMINI_API_KEY=your_api_key_here

--- a/README.md
+++ b/README.md
@@ -9,6 +9,6 @@ This contains everything you need to run your app locally.
 
 1. Install dependencies:
    `npm install`
-2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
+2. Copy `.env.example` to `.env.local` and set the `GEMINI_API_KEY` to your Gemini API key. Keep `.env.local` out of version control.
 3. Run the app:
    `npm run dev`


### PR DESCRIPTION
## Summary
- add `.env.example` with GEMINI_API_KEY placeholder
- update README with instructions on copying the example to `.env.local`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844182a43c4832a9b300a23b92d249d