### PR TITLE
Add SwiftUI iOS client

### DIFF
--- a/ios/DailyMealApp.swift
+++ b/ios/DailyMealApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct DailyMealApp: App {
+    var body: some Scene {
+        WindowGroup {
+            MainFormView()
+        }
+    }
+}

--- a/ios/Info.plist
+++ b/ios/Info.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleName</key>
+    <string>DailyMeal</string>
+    <key>GEMINI_API_KEY</key>
+    <string>$(GEMINI_API_KEY)</string>
+</dict>
+</plist>

--- a/ios/Models/MealMode.swift
+++ b/ios/Models/MealMode.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+enum MealMode: String, CaseIterable, Identifiable {
+    case fastFood = "fast-food"
+    case diningOut = "dining-out"
+    case cookHome = "cook-home"
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .fastFood: return "Fast Food"
+        case .diningOut: return "Restaurant Meal"
+        case .cookHome: return "Home Cooking"
+        }
+    }
+}

--- a/ios/Models/MealResult.swift
+++ b/ios/Models/MealResult.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+struct MealResult: Identifiable {
+    let id = UUID()
+    let text: String
+}

--- a/ios/Services/GeminiAPIService.swift
+++ b/ios/Services/GeminiAPIService.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+struct GeminiResponse: Decodable {
+    struct Candidate: Decodable {
+        struct Content: Decodable {
+            struct Part: Decodable { let text: String }
+            let parts: [Part]
+        }
+        let content: Content
+    }
+    let candidates: [Candidate]
+}
+
+class GeminiAPIService {
+    private let apiKey: String
+    private let session: URLSession
+
+    init(session: URLSession = .shared) {
+        guard let key = Bundle.main.object(forInfoDictionaryKey: "GEMINI_API_KEY") as? String else {
+            fatalError("GEMINI_API_KEY not set in Info.plist")
+        }
+        self.apiKey = key
+        self.session = session
+    }
+
+    func generateMeal(prompt: String) async throws -> String {
+        let urlString = "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-preview-04-17:generateContent?key=\(apiKey)"
+        guard let url = URL(string: urlString) else { throw URLError(.badURL) }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        let body: [String: Any] = [
+            "contents": [["parts": [["text": prompt]]]]
+        ]
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        let (data, response) = try await session.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+            throw URLError(.badServerResponse)
+        }
+        let decoded = try JSONDecoder().decode(GeminiResponse.self, from: data)
+        return decoded.candidates.first?.content.parts.first?.text ?? ""
+    }
+}

--- a/ios/ViewModels/MealViewModel.swift
+++ b/ios/ViewModels/MealViewModel.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+class MealViewModel: ObservableObject {
+    @Published var calories: String = "1500"
+    @Published var mealMode: MealMode = .fastFood
+    @Published var fastFoodType: String = "any"
+    @Published var diningTags: Set<String> = []
+    @Published var commonIngredients: Set<String> = []
+    @Published var extraIngredients: String = ""
+
+    @Published var result: MealResult?
+    @Published var isLoading: Bool = false
+    @Published var errorMessage: String?
+
+    private let service: GeminiAPIService
+
+    init(service: GeminiAPIService = GeminiAPIService()) {
+        self.service = service
+    }
+
+    func generateMeal() {
+        Task {
+            await generateMealTask()
+        }
+    }
+
+    @MainActor
+    private func generateMealTask() async {
+        isLoading = true
+        errorMessage = nil
+        result = nil
+        let prompt = buildPrompt()
+        do {
+            let text = try await service.generateMeal(prompt: prompt)
+            result = MealResult(text: text)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+        isLoading = false
+    }
+
+    private func buildPrompt() -> String {
+        var prompt = "Calories: \(calories).\n"
+        switch mealMode {
+        case .fastFood:
+            prompt += "Mode: Fast Food."
+            if fastFoodType != "any" { prompt += " Type: \(fastFoodType)." }
+            prompt += " Suggest a meal combination from common fast-food chains."
+        case .diningOut:
+            let tags = diningTags.joined(separator: ", ")
+            prompt += "Mode: Restaurant Meal. Preferences: \(tags)."
+        case .cookHome:
+            let extras = extraIngredients.split(separator: ",")
+                .map { $0.trimmingCharacters(in: .whitespaces) }
+            let all = Array(commonIngredients) + extras
+            let ingredients = all.joined(separator: ", ")
+            prompt += "Mode: Home Cooking. Ingredients: \(ingredients)."
+        }
+        prompt += " Return a concise meal plan with calories and macros." 
+        return prompt
+    }
+}

--- a/ios/Views/DiningOutOptionsView.swift
+++ b/ios/Views/DiningOutOptionsView.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+
+struct DiningOutOptionsView: View {
+    @ObservedObject var viewModel: MealViewModel
+
+    let tags = ["high protein", "low carb", "vegetarian", "vegan", "gluten-free", "budget-friendly"]
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            ForEach(tags, id: \.self) { tag in
+                Toggle(isOn: Binding(
+                    get: { viewModel.diningTags.contains(tag) },
+                    set: { isOn in
+                        if isOn { viewModel.diningTags.insert(tag) }
+                        else { viewModel.diningTags.remove(tag) }
+                    }
+                )) {
+                    Text(tag.capitalized)
+                }
+            }
+        }
+    }
+}
+
+struct DiningOutOptionsView_Previews: PreviewProvider {
+    static var previews: some View {
+        DiningOutOptionsView(viewModel: MealViewModel())
+            .padding()
+    }
+}

--- a/ios/Views/FastFoodOptionsView.swift
+++ b/ios/Views/FastFoodOptionsView.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+struct FastFoodOptionsView: View {
+    @ObservedObject var viewModel: MealViewModel
+
+    var body: some View {
+        Picker("Fast Food Type", selection: $viewModel.fastFoodType) {
+            Text("Any / General").tag("any")
+            Text("Burgers / American").tag("burgers")
+            Text("Mexican").tag("mexican")
+            Text("Pizza").tag("pizza")
+            Text("Sandwiches / Subs").tag("sandwiches")
+            Text("Chicken").tag("chicken")
+            Text("Asian / Chinese").tag("chinese")
+        }
+        .pickerStyle(MenuPickerStyle())
+    }
+}
+
+struct FastFoodOptionsView_Previews: PreviewProvider {
+    static var previews: some View {
+        FastFoodOptionsView(viewModel: MealViewModel())
+            .padding()
+    }
+}

--- a/ios/Views/HomeCookingOptionsView.swift
+++ b/ios/Views/HomeCookingOptionsView.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+
+struct HomeCookingOptionsView: View {
+    @ObservedObject var viewModel: MealViewModel
+
+    let commonIngredients = [
+        "Chicken Breast", "Ground Beef", "Salmon", "Eggs", "Tofu", "Rice",
+        "Pasta", "Quinoa", "Potatoes", "Broccoli", "Spinach", "Onions",
+        "Garlic", "Tomatoes", "Olive Oil", "Avocado"
+    ]
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            Text("Ingredients on Hand")
+                .font(.headline)
+            ForEach(commonIngredients, id: \.self) { ingredient in
+                Toggle(isOn: Binding(
+                    get: { viewModel.commonIngredients.contains(ingredient) },
+                    set: { isOn in
+                        if isOn { viewModel.commonIngredients.insert(ingredient) }
+                        else { viewModel.commonIngredients.remove(ingredient) }
+                    }
+                )) {
+                    Text(ingredient)
+                }
+            }
+            TextField("Additional ingredients (comma separated)", text: $viewModel.extraIngredients)
+                .textFieldStyle(RoundedBorderTextFieldStyle())
+        }
+    }
+}
+
+struct HomeCookingOptionsView_Previews: PreviewProvider {
+    static var previews: some View {
+        HomeCookingOptionsView(viewModel: MealViewModel())
+            .padding()
+    }
+}

--- a/ios/Views/MainFormView.swift
+++ b/ios/Views/MainFormView.swift
@@ -1,0 +1,62 @@
+import SwiftUI
+
+struct MainFormView: View {
+    @StateObject private var viewModel = MealViewModel()
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section(header: Text("Your Daily Calories")) {
+                    TextField("1500", text: $viewModel.calories)
+                        .keyboardType(.numberPad)
+                }
+
+                Section(header: Text("Meal Source")) {
+                    Picker("Meal Source", selection: $viewModel.mealMode) {
+                        ForEach(MealMode.allCases) { mode in
+                            Text(mode.displayName).tag(mode)
+                        }
+                    }
+                    .pickerStyle(SegmentedPickerStyle())
+
+                    switch viewModel.mealMode {
+                    case .fastFood:
+                        FastFoodOptionsView(viewModel: viewModel)
+                    case .diningOut:
+                        DiningOutOptionsView(viewModel: viewModel)
+                    case .cookHome:
+                        HomeCookingOptionsView(viewModel: viewModel)
+                    }
+                }
+
+                Section {
+                    Button("Get My Daily Meal") {
+                        viewModel.generateMeal()
+                    }
+                }
+
+                if let result = viewModel.result {
+                    Section {
+                        ResultView(text: result.text, regenerateAction: viewModel.generateMeal)
+                    }
+                }
+
+                if viewModel.isLoading {
+                    ProgressView("Finding your Daily Meal...")
+                }
+
+                if let error = viewModel.errorMessage {
+                    Text(error)
+                        .foregroundColor(.red)
+                }
+            }
+            .navigationTitle("Daily Meal")
+        }
+    }
+}
+
+struct MainFormView_Previews: PreviewProvider {
+    static var previews: some View {
+        MainFormView()
+    }
+}

--- a/ios/Views/ResultView.swift
+++ b/ios/Views/ResultView.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+struct ResultView: View {
+    let text: String
+    let regenerateAction: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(text)
+                .padding()
+            Button("Try Another Meal") {
+                regenerateAction()
+            }
+        }
+    }
+}
+
+struct ResultView_Previews: PreviewProvider {
+    static var previews: some View {
+        ResultView(text: "Sample meal result", regenerateAction: {})
+            .padding()
+    }
+}


### PR DESCRIPTION
## Summary
- add a SwiftUI iOS app under `ios/`
- implement `MainFormView` for user inputs
- implement `MealViewModel` and `GeminiAPIService`
- include views for specific meal modes
- store the API key in `Info.plist`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684418294b40832abc44e6c02e81081f